### PR TITLE
Add auto-assign-pr workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set the organizers team as the default owners for all files in the repository.
+* @cloudnativesdq/organizers

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -20,9 +20,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
         run: |
-          echo "Processing PR #$PR_NUMBER..."
+          echo "Processing PR #$PR_NUMBER (Author: $PR_AUTHOR)..."
 
           # Parse OWNERS_ALIASES using yq (pre-installed on ubuntu-latest)
           if [ -f OWNERS_ALIASES ]; then
@@ -30,21 +31,35 @@ jobs:
             WOMEN_IN_CLOUD=$(yq '.aliases.women-in-cloud-native-organizers[]' OWNERS_ALIASES 2>/dev/null | tr '\n' ',' | sed 's/,$//')
           fi
 
-          # Assign PR to organizers (individuals)
-          if [ -n "$ORGANIZERS" ]; then
-            echo "Assigning PR to organizers: $ORGANIZERS"
-            gh pr edit "$PR_NUMBER" --add-assignee "$ORGANIZERS" --repo "$REPO"
-          else
-            echo "No individual organizers found in OWNERS_ALIASES."
+          # Assign PR to the author of the PR
+          echo "Assigning PR to author: $PR_AUTHOR"
+          gh pr edit "$PR_NUMBER" --add-assignee "$PR_AUTHOR" --repo "$REPO"
+
+          # Function to filter out PR author from reviewers to prevent GitHub API errors
+          filter_author() {
+            local list=$1
+            local author=$2
+            echo "$list" | tr ',' '\n' | grep -v -x "$author" | tr '\n' ',' | sed 's/,$//'
+          }
+
+          CLEAN_ORGANIZERS=$(filter_author "$ORGANIZERS" "$PR_AUTHOR")
+          CLEAN_WOMEN_IN_CLOUD=$(filter_author "$WOMEN_IN_CLOUD" "$PR_AUTHOR")
+
+          # Request review from individual organizers
+          if [ -n "$CLEAN_ORGANIZERS" ]; then
+            echo "Requesting review from organizers: $CLEAN_ORGANIZERS"
+            gh pr edit "$PR_NUMBER" --add-reviewer "$CLEAN_ORGANIZERS" --repo "$REPO"
           fi
 
           # Request review from individual women-in-cloud-native-organizers
-          if [ -n "$WOMEN_IN_CLOUD" ]; then
-            echo "Requesting review from: $WOMEN_IN_CLOUD"
-            gh pr edit "$PR_NUMBER" --add-reviewer "$WOMEN_IN_CLOUD" --repo "$REPO"
+          if [ -n "$CLEAN_WOMEN_IN_CLOUD" ]; then
+            echo "Requesting review from women-in-cloud-native: $CLEAN_WOMEN_IN_CLOUD"
+            gh pr edit "$PR_NUMBER" --add-reviewer "$CLEAN_WOMEN_IN_CLOUD" --repo "$REPO"
           fi
 
           # Request review from teams on GitHub (as teams)
           echo "Requesting review from teams..."
+          gh pr edit "$PR_NUMBER" --add-reviewer "cloudnativesdq/organizers" --repo "$REPO" || true
           gh pr edit "$PR_NUMBER" --add-reviewer "cloudnativesdq/women-in-cloud-native-organizers" --repo "$REPO" || true
           gh pr edit "$PR_NUMBER" --add-reviewer "cloudnativesdq/women-in-cloud-native" --repo "$REPO" || true
+

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,50 @@
+name: Cloud Native SDQ - Auto Assign PR
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Assign Reviewers and Assignees
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Processing PR #$PR_NUMBER..."
+
+          # Parse OWNERS_ALIASES using yq (pre-installed on ubuntu-latest)
+          if [ -f OWNERS_ALIASES ]; then
+            ORGANIZERS=$(yq '.aliases.organizers[]' OWNERS_ALIASES 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+            WOMEN_IN_CLOUD=$(yq '.aliases.women-in-cloud-native-organizers[]' OWNERS_ALIASES 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+          fi
+
+          # Assign PR to organizers (individuals)
+          if [ -n "$ORGANIZERS" ]; then
+            echo "Assigning PR to organizers: $ORGANIZERS"
+            gh pr edit "$PR_NUMBER" --add-assignee "$ORGANIZERS" --repo "$REPO"
+          else
+            echo "No individual organizers found in OWNERS_ALIASES."
+          fi
+
+          # Request review from individual women-in-cloud-native-organizers
+          if [ -n "$WOMEN_IN_CLOUD" ]; then
+            echo "Requesting review from: $WOMEN_IN_CLOUD"
+            gh pr edit "$PR_NUMBER" --add-reviewer "$WOMEN_IN_CLOUD" --repo "$REPO"
+          fi
+
+          # Request review from teams on GitHub (as teams)
+          echo "Requesting review from teams..."
+          gh pr edit "$PR_NUMBER" --add-reviewer "cloudnativesdq/women-in-cloud-native-organizers" --repo "$REPO" || true
+          gh pr edit "$PR_NUMBER" --add-reviewer "cloudnativesdq/women-in-cloud-native" --repo "$REPO" || true


### PR DESCRIPTION
Add a GitHub Actions workflow to automatically assign PRs to the organizers (approvers) and request reviews from the women-in-cloud-native-organizers team based on OWNERS_ALIASES.