### PR TITLE
Move events handbook to events README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Para facilitar la organización y el acceso a la información, contamos con los 
 
 *   🌐 **Sitio Web Oficial:** Descubre nuestras últimas noticias, registro a meetups y recursos en [cloudnativesdq.org](https://cloudnativesdq.org).
 *   💻 **Código Fuente del Sitio Web:** El sitio web oficial está desarrollado en código abierto. Puedes encontrar y colaborar con el código fuente en el repositorio del mismo nombre: **[cloudnativesdq.org](https://github.com/cloudnativesdq/cloudnativesdq.org)**.
-*   📖 **Manual de Organización de Eventos:** Guía general para la logística de eventos locales. Consulta el documento principal en: **[manual_de_eventos.md](file:///Users/tineoc/Documents/Code/chapter/manual_de_eventos.md)**.
+*   📖 **Manual de Organización de Eventos:** Guía general para la logística de eventos locales. Consulta el documento principal en: **[eventos/README.md](eventos/README.md)**.
 
 ---
 
@@ -18,10 +18,10 @@ Para facilitar la organización y el acceso a la información, contamos con los 
 
 Hemos estructurado guías específicas para cada uno de los roles clave que hacen posibles nuestros eventos:
 
-*   🏢 **[Manual del Personal Organizador (Staff)](file:///Users/tineoc/Documents/Code/chapter/eventos/staff-handbook.md)**: Roles del Event Lead, Ops Lead, Content Lead, Comms Lead, junto con cronogramas de hitos previos y posteriores al evento y detalles del programa de sombras (shadowing).
-*   🎫 **[Manual del Voluntario (Volunteers)](file:///Users/tineoc/Documents/Code/chapter/eventos/volunteers-handbook.md)**: Instrucciones paso a paso para el registro/check-in de asistentes, control de acceso, paso de micrófonos de sala, guías de pasillo y cobertura digital del evento.
-*   🎤 **[Manual del Ponente (Speakers)](file:///Users/tineoc/Documents/Code/chapter/eventos/speakers-handbook.md)**: Directrices para los expositores sobre accesibilidad visual de diapositivas, inclusividad lingüística, plazos de entrega y logística en sitio.
-*   🍎 **[Guía de Coordinación de Alimentos y Proveedores (Catering Guide)](file:///Users/tineoc/Documents/Code/chapter/eventos/proveedores-comida.md)**: Criterios para la reserva y entrega de alimentos con al menos una semana de antelación y protocolo especial de transporte para el tránsito complejo de Santo Domingo.
+*   🏢 **[Manual del Personal Organizador (Staff)](eventos/staff-handbook.md)**: Roles del Event Lead, Ops Lead, Content Lead, Comms Lead, junto con cronogramas de hitos previos y posteriores al evento y detalles del programa de sombras (shadowing).
+*   🎫 **[Manual del Voluntario (Volunteers)](eventos/volunteers-handbook.md)**: Instrucciones paso a paso para el registro/check-in de asistentes, control de acceso, paso de micrófonos de sala, guías de pasillo y cobertura digital del evento.
+*   🎤 **[Manual del Ponente (Speakers)](eventos/speakers-handbook.md)**: Directrices para los expositores sobre accesibilidad visual de diapositivas, inclusividad lingüística, plazos de entrega y logística en sitio.
+*   🍎 **[Guía de Coordinación de Alimentos y Proveedores (Catering Guide)](eventos/proveedores-comida.md)**: Criterios para la reserva y entrega de alimentos con al menos una semana de antelación y protocolo especial de transporte para el tránsito complejo de Santo Domingo.
 
 *Todos los manuales y guías están interconectados con enlaces Markdown para facilitar una navegación rápida.*
 

--- a/eventos/README.md
+++ b/eventos/README.md
@@ -61,9 +61,22 @@ Es un requisito mandatorio para todos los asistentes, ponentes, voluntarios y mi
 
 Para que el evento funcione con la precisión de un reloj, es fundamental delimitar los roles. A continuación se presentan las responsabilidades clave inspiradas en el modelo del Kubernetes Contributor Summit:
 
+### Tabla de Roles, Descripción y Requerimientos
+
+Un evento requiere al menos **1 Staff** y por lo menos **2 Voluntarios**. Sin embargo, ante la falta o ausencia de voluntarios, el Staff deberá asumir y repartirse las funciones operativas de estos para garantizar la viabilidad del evento.
+
+| Rol | Manual / Recurso | Descripción | Cantidad Mínima / Estimada |
+| :--- | :--- | :--- | :--- |
+| **Staff (Organizador)** | [Manual de Staff](staff-handbook.md) | Dirección estratégica del evento, administración del presupuesto, coordinación de proveedores, atención al Código de Conducta y gestión del programa de Shadows. | **Mínimo 1** |
+| **Voluntario (Volunteer)** | [Manual de Voluntarios](volunteers-handbook.md) | Soporte operativo en el sitio: check-in, paso de micrófonos en Q&A, guiar a los asistentes (attendees), tirar fotos y subir guías de navegación/ubicación. | **Mínimo 2** (el Staff asume sus roles si no hay voluntarios) |
+| **Ponente (Speaker)** | [Manual de Ponente](speakers-handbook.md) | Compartir conocimiento técnico, preparar presentaciones accesibles/inclusivas y cumplir el Código de Conducta. | Variable (según agenda) |
+| **Proveedor de Comida** | [Guía de Alimentos](proveedores-comida.md) | Preparar, etiquetar (alérgenos) y transportar catering o refrigerios. | Opcional (1 proveedor) |
+
+---
+
 ### A. Staff (Personal Organizador y Líderes)
 
-El Staff está compuesto por los directores y líderes de área que planifican el evento meses antes del gran día. Para una guía operativa completa orientada a organizadores y el cronograma de hitos, consulta el **[Manual del Personal Organizador (Staff)](file:///Users/tineoc/Documents/Code/chapter/eventos/staff-handbook.md)**.
+El Staff está compuesto por los directores y líderes de área que planifican el evento meses antes del gran día. Para una guía operativa completa orientada a organizadores y el cronograma de hitos, consulta el **[Manual del Personal Organizador (Staff)](staff-handbook.md)**.
 
 > [!TIP]
 > **Separación de Roles Recomendada:** Se recomienda encarecidamente que los miembros del Staff y los Ponentes (*Speakers*) sean personas separadas. Esto previene la sobrecarga de trabajo de los organizadores y asegura que los ponentes puedan enfocarse en el contenido de su charla sin la distracción de resolver problemas logísticos del evento en tiempo real.
@@ -102,7 +115,7 @@ El Staff está compuesto por los directores y líderes de área que planifican e
 
 ### B. Voluntarios (Volunteers)
 
-Los voluntarios son el motor del evento el día de su ejecución. Sus turnos suelen ser de 1 o 2 horas para permitirles disfrutar también de las conferencias. Para ver instrucciones detalladas de los roles, listas de verificación y protocolos de emergencia, consulta el **[Manual del Voluntario (Volunteers)](file:///Users/tineoc/Documents/Code/chapter/eventos/volunteers-handbook.md)**.
+Los voluntarios son el motor del evento el día de su ejecución. Sus turnos suelen ser de 1 o 2 horas para permitirles disfrutar también de las conferencias. Para ver instrucciones detalladas de los roles, listas de verificación y protocolos de emergencia, consulta el **[Manual del Voluntario (Volunteers)](volunteers-handbook.md)**.
 
 > [!IMPORTANT]
 > **Delegación de Funciones a Voluntarios:** El Líder de Operaciones debe contactar y convocar a los voluntarios seleccionados antes del evento para delegar de forma estructurada las siguientes tareas:
@@ -140,7 +153,7 @@ Los voluntarios son el motor del evento el día de su ejecución. Sus turnos sue
 
 ### C. Ponentes (Speakers)
 
-Los ponentes son responsables de la transferencia de conocimiento técnico y cultural en el evento. Para pautas completas de inclusividad, diseño de diapositivas accesibles y logística en sitio, consulta el **[Manual del Ponente (Speakers)](file:///Users/tineoc/Documents/Code/chapter/eventos/speakers-handbook.md)**.
+Los ponentes son responsables de la transferencia de conocimiento técnico y cultural en el evento. Para pautas completas de inclusividad, diseño de diapositivas accesibles y logística en sitio, consulta el **[Manual del Ponente (Speakers)](speakers-handbook.md)**.
 
 #### Responsabilidades
 *   **Antes del Evento:**
@@ -184,7 +197,7 @@ El espacio físico define la accesibilidad, comodidad y profesionalismo del even
 
 ### B. Comida y Catering (Food)
 
-Ofrecer comida y bebida inclusivas es vital para garantizar la salud y comodidad de todos los participantes. Para una guía operativa completa sobre compras, plazos y transporte de comida en entornos de tránsito complejo, consulta la **[Guía de Coordinación de Alimentos y Proveedores](file:///Users/tineoc/Documents/Code/chapter/eventos/proveedores-comida.md)**.
+Ofrecer comida y bebida inclusivas es vital para garantizar la salud y comodidad de todos los participantes. Para una guía operativa completa sobre compras, plazos y transporte de comida en entornos de tránsito complejo, consulta la **[Guía de Coordinación de Alimentos y Proveedores](proveedores-comida.md)**.
 
 *   **Decisión y Presupuesto:** Los eventos no necesitan obligatoriamente dar refrigerio o almuerzo, pero en caso de decidir hacerlo, el servicio de comida debe reservarse y pagarse con al menos una semana de antelación.
 *   **Logística de Entrega (Delivery):** Se recomienda muy especialmente coordinar el envío directo con el proveedor a la sede (*venue*). Nunca se debe coordinar el delivery a último momento.

--- a/eventos/proveedores-comida.md
+++ b/eventos/proveedores-comida.md
@@ -1,6 +1,6 @@
 # Guía de Coordinación de Alimentos y Proveedores (Catering Guide)
 
-Este documento establece las directrices logísticas para la selección, contratación y gestión del servicio de comida y catering durante los eventos de la comunidad. Para más información sobre el flujo logístico general, consulta el **[Manual de Organización de Eventos General](file:///Users/tineoc/Documents/Code/chapter/manual_de_eventos.md)**.
+Este documento establece las directrices logísticas para la selección, contratación y gestión del servicio de comida y catering durante los eventos de la comunidad. Para más información sobre el flujo logístico general, consulta el **[Manual de Organización de Eventos General](README.md)**.
 
 ---
 

--- a/eventos/speakers-handbook.md
+++ b/eventos/speakers-handbook.md
@@ -1,6 +1,6 @@
 # Manual del Ponente (Speakers Handbook)
 
-¡Felicitaciones por haber sido seleccionado como ponente en nuestro evento! Tu participación es fundamental para enriquecer el conocimiento técnico y el crecimiento profesional de nuestra comunidad. Este manual te proporciona las pautas necesarias para preparar y realizar tu presentación con éxito. Si deseas conocer la logística general de la sede o el Código de Conducta completo, revisa el **[Manual de Organización de Eventos General](file:///Users/tineoc/Documents/Code/chapter/manual_de_eventos.md)**.
+¡Felicitaciones por haber sido seleccionado como ponente en nuestro evento! Tu participación es fundamental para enriquecer el conocimiento técnico y el crecimiento profesional de nuestra comunidad. Este manual te proporciona las pautas necesarias para preparar y realizar tu presentación con éxito. Si deseas conocer la logística general de la sede o el Código de Conducta completo, revisa el **[Manual de Organización de Eventos General](README.md)**.
 
 > [!IMPORTANT]
 > Todos los ponentes deben cumplir de manera obligatoria y rigurosa con el **[Código de Conducta de la CNCF](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/es/code-of-conduct-es.md)** en su comportamiento, lenguaje y el contenido visual expuesto en sus diapositivas y demostraciones.

--- a/eventos/staff-handbook.md
+++ b/eventos/staff-handbook.md
@@ -25,18 +25,18 @@ El equipo organizador principal está compuesto por las siguientes figuras, cada
 ### 2. Líder de Operaciones (Ops Lead)
 *   **Enfoque:** Logística en sitio, infraestructura física y coordinación de voluntarios.
 *   **Responsabilidades:**
-    *   Diseñar y supervisar el flujo de registro, catering y distribución de las salas *(para detalles de catering, ver [Guía de Alimentos y Proveedores](file:///Users/tineoc/Documents/Code/chapter/eventos/proveedores-comida.md))*.
+    *   Diseñar y supervisar el flujo de registro, catering y distribución de las salas *(para detalles de catering, ver [Guía de Alimentos y Proveedores](proveedores-comida.md))*.
     *   Elaborar la matriz de turnos para los voluntarios y liderar la sesión de orientación el día del evento.
     *   Coordinar con los proveedores de servicios del lugar (personal técnico, limpieza, seguridad y catering).
     *   Establecer y vigilar la Sala de Staff (Staff Room).
-    *   Contactar y convocar a los voluntarios previamente para delegarles funciones específicas (check-in, guiar a asistentes, pasar micrófonos, tirar fotos y publicar contenido digital de cómo llegar al salón o sede) *(para pautas de asignación y checklists de voluntarios, ver [Manual del Voluntario](file:///Users/tineoc/Documents/Code/chapter/eventos/volunteers-handbook.md))*.
+    *   Contactar y convocar a los voluntarios previamente para delegarles funciones específicas (check-in, guiar a asistentes, pasar micrófonos, tirar fotos y publicar contenido digital de cómo llegar al salón o sede) *(para pautas de asignación y checklists de voluntarios, ver [Manual del Voluntario](volunteers-handbook.md))*.
 
 ### 3. Líder de Contenido (Content Lead)
 *   **Enfoque:** Agenda académica, ponentes y material de presentación.
 *   **Responsabilidades:**
     *   Organizar el comité de revisión para la Convocatoria de Ponencias (CFP).
     *   Estructurar la agenda horaria del evento evitando solapamientos críticos de temáticas.
-    *   Mantener comunicación directa con los ponentes seleccionados para guiarles en los plazos de entrega *(para las directrices que deben seguir los expositores, ver [Manual del Ponente](file:///Users/tineoc/Documents/Code/chapter/eventos/speakers-handbook.md))*.
+    *   Mantener comunicación directa con los ponentes seleccionados para guiarles en los plazos de entrega *(para las directrices que deben seguir los expositores, ver [Manual del Ponente](speakers-handbook.md))*.
     *   Verificar que las salas cuenten con los recursos específicos solicitados por los ponentes (ej. pizarras, conexiones HDMI/USB-C especiales).
 
 ### 4. Líder de Comunicación (Comms Lead)

--- a/eventos/volunteers-handbook.md
+++ b/eventos/volunteers-handbook.md
@@ -1,6 +1,6 @@
 # Manual del Voluntario (Volunteers Handbook)
 
-¡Gracias por ofrecer tu tiempo para ayudar a nuestra comunidad! Este manual contiene la información práctica que necesitas para desempeñar tus funciones de voluntariado en el evento de forma fluida y satisfactoria. Si deseas consultar las políticas logísticas generales de la sede y el flujo global, revisa el **[Manual de Organización de Eventos General](file:///Users/tineoc/Documents/Code/chapter/manual_de_eventos.md)**.
+¡Gracias por ofrecer tu tiempo para ayudar a nuestra comunidad! Este manual contiene la información práctica que necesitas para desempeñar tus funciones de voluntariado en el evento de forma fluida y satisfactoria. Si deseas consultar las políticas logísticas generales de la sede y el flujo global, revisa el **[Manual de Organización de Eventos General](README.md)**.
 
 > [!IMPORTANT]
 > Todos los voluntarios deben conocer, cumplir y hacer cumplir el **[Código de Conducta de la CNCF](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/es/code-of-conduct-es.md)**. Al ser la cara visible del evento, nuestro trato debe ser siempre inclusivo, respetuoso y empático.
@@ -67,7 +67,7 @@ Como voluntario en el sitio, eres la cara visible del evento para los asistentes
     *   [ ] Posiciónate en los cruces de pasillos principales. Saluda a las personas extraviadas y dirígelas (guiar a los attendees) hacia las salas correspondientes, los sanitarios o el comedor.
     *   [ ] Durante las transiciones de charlas, asiste al Ops Lead en agilizar el flujo de salida y entrada en las aulas.
     *   [ ] Como *Runner*, mantente en comunicación en Slack para responder solicitudes urgentes de material (ej: *"Llevar un adaptador USB-C a HDMI de repuesto a la Sala B"*, *"Llevar agua para ponente a la Sala C"*).
-    *   [ ] **Nota de Transporte de Alimentos (Si aplica):** Si te has ofrecido a transportar o recoger comida el día del evento, recuerda que por seguridad logística tu única función para ese día será esa labor debido al tránsito impredecible de Rep Dom *(ver detalles y restricciones en la [Guía de Coordinación de Alimentos y Proveedores](file:///Users/tineoc/Documents/Code/chapter/eventos/proveedores-comida.md))*.
+    *   [ ] **Nota de Transporte de Alimentos (Si aplica):** Si te has ofrecido a transportar o recoger comida el día del evento, recuerda que por seguridad logística tu única función para ese día será esa labor debido al tránsito impredecible de Rep Dom *(ver detalles y restricciones en la [Guía de Coordinación de Alimentos y Proveedores](proveedores-comida.md))*.
 
 ---
 


### PR DESCRIPTION
Move manual_de_eventos.md to eventos/README.md. Update all links to relative path formatting. Include a table of roles, descriptions, and minimum staff and volunteers requirements in the events README.